### PR TITLE
Workaround for WPML bug - ACF field types missing

### DIFF
--- a/src/Field/FlexibleContent.php
+++ b/src/Field/FlexibleContent.php
@@ -99,8 +99,25 @@ class FlexibleContent extends BasicField implements FieldInterface
             $post = $this->post->ID != $meta->post_id ? $this->post->find($meta->post_id) : $this->post;
             $field = FieldFactory::make($meta->meta_key, $post);
 
-            if ($field === null || !array_key_exists($id, $blocks)) {
+            if (!array_key_exists($id, $blocks)) {
                 continue;
+            }
+
+            if ($field === null) {
+                $acfFieldType = $this->getFieldTypeByFieldName($name);
+
+                if ($acfFieldType === null) {
+                    $acfFieldType = $this->getFieldTypeByLayoutName($blocks[$id]);
+
+                    if ($acfFieldType === null) {
+                        continue;
+                    }
+                }
+
+                $field = FieldFactory::make($meta->meta_key, $post, $acfFieldType);
+                if ($field === null) {
+                    continue;
+                }
             }
 
             if (empty($fields[$id])) {
@@ -115,5 +132,63 @@ class FlexibleContent extends BasicField implements FieldInterface
         ksort($fields);
 
         return $fields;
+    }
+
+    protected function getFieldTypeByFieldName(string $fieldName): ?string
+    {
+        switch ($fieldName) {
+            case 'html_content':
+            case 'text_content':
+            case 'headline':
+            case 'videoId':
+            case 'channelId':
+                $acfFieldType = 'text';
+                break;
+            case 'display_type':
+            case 'alignment':
+            case 'newsletter_list':
+                $acfFieldType = 'select';
+                break;
+            case 'image_gallery':
+                $acfFieldType = 'gallery';
+                break;
+            case 'image':
+                $acfFieldType = 'image';
+                break;
+            case 'location_repeater':
+            case 'products_repeater':
+            case 'fact_repeater':
+                $acfFieldType = 'repeater';
+                break;
+            case 'acf_hide_layout':
+            case 'autoplay':
+                $acfFieldType = 'boolean';
+                break;
+            default:
+                $acfFieldType = null;
+                break;
+        }
+
+        return $acfFieldType;
+    }
+
+    protected function getFieldTypeByLayoutName($fieldType): ?string
+    {
+        switch ($fieldType) {
+            case 'text_editor':
+            case 'html_editor':
+            case 'newsletter_section':
+                $acfFieldType = 'text';
+                break;
+            case 'competition':
+            case 'magazine_selection':
+                $acfFieldType = 'post_object';
+                break;
+            default:
+                $acfFieldType = null;
+                break;
+        }
+
+        return $acfFieldType;
     }
 }

--- a/src/Field/Repeater.php
+++ b/src/Field/Repeater.php
@@ -75,7 +75,7 @@ class Repeater extends BasicField implements FieldInterface
     protected function fetchPostsMeta($fieldName, $post)
     {
         $count = (int) $this->fetchValue($fieldName);
-        
+
         if ($this->postMeta instanceof \Corcel\Model\Meta\TermMeta) {
             $builder = $this->postMeta->where('term_id', $post->term_id);
         } else {
@@ -107,13 +107,41 @@ class Repeater extends BasicField implements FieldInterface
             $post = $this->post->ID != $meta->post_id ? $this->post->find($meta->post_id) : $this->post;
             $field = FieldFactory::make($meta->meta_key, $post);
 
-            if ($field == null) {
-                continue;
+            if ($field === null) {
+                $acfFieldType = $this->getFieldTypeByFieldName($name);
+
+                if ($acfFieldType === null) {
+                    continue;
+                }
+
+                $field = FieldFactory::make($meta->meta_key, $post, $acfFieldType);
+                if ($field === null) {
+                    continue;
+                }
             }
 
             $fields[$id][$name] = $field->get();
         }
 
         return $fields;
+    }
+
+    protected function getFieldTypeByFieldName(string $fieldName): ?string
+    {
+        switch ($fieldName) {
+            case 'fact_headline':
+            case 'fact_text':
+                $acfFieldType = 'text';
+                break;
+            case 'location_single':
+            case 'product_single':
+                $acfFieldType = 'select';
+                break;
+            default:
+                $acfFieldType = null;
+                break;
+        }
+
+        return $acfFieldType;
     }
 }


### PR DESCRIPTION
Workaround for WPML bug resulting in lost ACF field type meta records for Repeater and FlexibleContent fields.

If the FieldFactory was not able to identify the field type, we're going to try to create the `$field` object according to a mapping of its name and/or parent layout name with the available field types.

If there's still no field identified, the field is skipped, just like before these changes.